### PR TITLE
Created get and post endpoints for planned and completed courses

### DIFF
--- a/api/school/urls.py
+++ b/api/school/urls.py
@@ -7,15 +7,15 @@ router = routers.DefaultRouter()
 urlpatterns = [
     path('', include(router.urls)),
 
-    path('schools/', views.SchoolList.as_view()),
-    path('schools/<uuid:school_id>/', views.SchoolDetail.as_view()),
-    path('schools/<uuid:school_id>/majors/', views.MajorList.as_view()),
+    path('schools', views.SchoolList.as_view()),
+    path('schools/<uuid:school_id>', views.SchoolDetail.as_view()),
+    path('schools/<uuid:school_id>/majors', views.MajorList.as_view()),
 
-    path('major/<uuid:major_id>/', views.MajorDetail.as_view()),
-    path('major/<uuid:major_id>/groups/', views.GroupList.as_view()),
+    path('major/<uuid:major_id>', views.MajorDetail.as_view()),
+    path('major/<uuid:major_id>/groups', views.GroupList.as_view()),
 
-    path('group/<uuid:group_id>/', views.GroupDetail.as_view()),
-    path('group/<uuid:group_id>/courses/', views.GroupCoursesList.as_view()),
+    path('group/<uuid:group_id>', views.GroupDetail.as_view()),
+    path('group/<uuid:group_id>/courses', views.GroupCoursesList.as_view()),
 
-    path('course/<uuid:course_id>/', views.CourseDetail.as_view()),
+    path('course/<uuid:course_id>', views.CourseDetail.as_view()),
 ]

--- a/api/student/serializers.py
+++ b/api/student/serializers.py
@@ -5,7 +5,7 @@ class PlannedCourseSerializer(serializers.ModelSerializer):
     class Meta:
         depth = 1
         model = PlannedCourse
-        fields = '__all__'
+        exclude = ['student']
 
 class CompletedCourseSerializer(serializers.ModelSerializer):
     class Meta:

--- a/api/student/urls.py
+++ b/api/student/urls.py
@@ -4,4 +4,6 @@ from student import views
 urlpatterns = [
     path('login', views.Login.as_view()),
     path('register', views.Register.as_view()),
+    path('planned', views.PlannedCourses.as_view()),
+    path('completed', views.CompletedCourses.as_view()),
 ]


### PR DESCRIPTION
This gives endpoints for retrieving planned and completed courses, and creating new ones.

JSON body for new completed course: POST -> /student/completed
```
{
   "course_id": "idsdfasdfasdfasdf"
}
```

it will automatically retrieve the course and add it to the student

JSON body for new planned course: POST -> /student/planned
```
{
    "course_id": "idasdfasdfasdfas",
    "year": 2020,
    "semester": "F" # valid choices are F | W | Sp | Su
}
```

for all /student endpoints, must have the "Authorization: Token asdfasdfsadfs" header